### PR TITLE
Solve circular dependency issue and add example of it working in the preact app

### DIFF
--- a/preact-app/appName.js
+++ b/preact-app/appName.js
@@ -1,0 +1,3 @@
+import { framework } from "./title";
+
+export const appName = `${framework}-app`;

--- a/preact-app/appName.js
+++ b/preact-app/appName.js
@@ -1,3 +1,3 @@
 import { framework } from "./title";
 
-export const appName = `${framework}-app`;
+export const getAppName = () => `${framework}-app`;

--- a/preact-app/entry-server.jsx
+++ b/preact-app/entry-server.jsx
@@ -2,7 +2,7 @@ import preactRender from "preact-render-to-string";
 import { h } from "preact";
 import Component from "./Component";
 
-const title = await import("./title").then((m) => m.title);
+const title = await import("./title").then((m) => m.getTitle());
 
 export function render(url) {
 	return preactRender(

--- a/preact-app/title.js
+++ b/preact-app/title.js
@@ -1,5 +1,5 @@
-import { appName } from './appName';
+import { getAppName } from './appName';
 
-export const title = `${appName}`;
+export const getTitle = () => `${getAppName()}`;
 
 export const framework = 'preact';

--- a/preact-app/title.js
+++ b/preact-app/title.js
@@ -1,1 +1,5 @@
-export const title = "APP TITLE!";
+import { appName } from './appName';
+
+export const title = `${appName}`;
+
+export const framework = 'preact';

--- a/workerd-vite-utils/src/index.ts
+++ b/workerd-vite-utils/src/index.ts
@@ -33,8 +33,6 @@ export function createWorkerdHandler(opts: {
 		const url = new URL(`http://localhost${request.url}`);
 		const moduleId = url.searchParams.get("moduleId");
 
-		console.log(`\x1b[46m workerd loading - ${moduleId} \x1b[0m`);
-
 		const moduleCode = (
 			await server.transformRequest(moduleId, {
 				ssr: true,

--- a/workerd-vite-utils/src/index.ts
+++ b/workerd-vite-utils/src/index.ts
@@ -33,6 +33,8 @@ export function createWorkerdHandler(opts: {
 		const url = new URL(`http://localhost${request.url}`);
 		const moduleId = url.searchParams.get("moduleId");
 
+		console.log(`\x1b[46m workerd loading - ${moduleId} \x1b[0m`);
+
 		const moduleCode = (
 			await server.transformRequest(moduleId, {
 				ssr: true,

--- a/workerd-vite-utils/src/workerdBootloader.js.txt
+++ b/workerd-vite-utils/src/workerdBootloader.js.txt
@@ -22,6 +22,11 @@ async function __vite_ssr_import__(moduleId) {
 
     let moduleObject = Object.create(null);
 
+    // instead of adding the module to the registry once it has been fully initialized we
+    // set it as soon as we've generated the object (even if empty), we do this so that
+    // we can prevent circular dependencies from generating infinite loops
+    __ourPrivateModuleRegistry__.set(moduleId, moduleObject)
+
     // // copy from Vite's node implementation?
     // const __vite_ssr_exportAll__ = 'something';
     // //
@@ -47,8 +52,7 @@ async function __vite_ssr_import__(moduleId) {
     await fn(...Object.values(context));
     Object.assign(moduleObject, context.__vite_ssr_exports__);
 
-    // `module` should now have all the exports registered on it
-    __ourPrivateModuleRegistry__.set(moduleId, moduleObject)
+    // `module` should now have all the exports registered on it now
 
     return moduleObject;
 }


### PR DESCRIPTION
`preact-app/title.js` imports from `preact-app/appName.js` which imports from `preact-app/title.js`

before the changes applied in the bootloader this would result in an infinite loop, causing the plugin to never serve the page, now it serves the pages as it should